### PR TITLE
Fixed endpoint names and streamlabs message handling

### DIFF
--- a/public/scripts/bar.js
+++ b/public/scripts/bar.js
@@ -106,7 +106,7 @@ function startSocket(streamlabs) {
         console.log(eventData);
 
         //Ignore stream labels general info messages
-        if (eventData.type == "streamlabels.underlying" || eventData.type == "streamlabels") {
+        if (eventData.type == "streamlabels.underlying" || eventData.type == "streamlabels" || eventData.type == "reload.instant") {
             return;
         }
 

--- a/routes/api/goal.js
+++ b/routes/api/goal.js
@@ -20,7 +20,7 @@ router.get('/', (req, res) => {
 //@desc     Get all goals
 //@access   Public
 //TODO      Could have this use twitch oauth to access the correct goal  
-router.get('/:channel', (req, res) => {
+router.get('/channel/:channel', (req, res) => {
     Goal.findOne({ channel: req.params.channel })
         .then(goal => res.json(goal));
 });


### PR DESCRIPTION
* Endpoint names with parameters were blocking other endpoints from firing.
* Added an event.type to ignore from the streamlabs socket API.