### PR TITLE
Removed updateProgress API calls from frontend

### DIFF
--- a/client/src/pages/GoalBar.js
+++ b/client/src/pages/GoalBar.js
@@ -38,25 +38,24 @@ class GoalBar extends Component {
 
     //Fetch call to update the goal's progress.
     updateProgress = (progress) => {
-        fetch(`${url}/api/goal/updateProgress/${this.state.channel}`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-            },
-            body: JSON.stringify({ progress: progress }),
-        });
+        const totalProgress = this.state.progress + progress;
+
+        this.setState({ ...this.state, progress: totalProgress });
     };
 
     componentDidMount() {
         //TODO: Dynamic routes for tokens.
-        const token = Math.floor(Math.random() * 2);
+
         socket = io(`${socketUrl}?token=123`);
 
         //TODO: Update front end from eventData.
         socket.on("event", (eventData) => {
             console.log(eventData);
+            const amount = eventData["amount"];
+            this.updateProgress(amount);
         });
 
+        //Needs to be based on props in future.
         fetch(`${url}/api/goal`)
             .then((response) => response.json())
             .then((json) => {

--- a/routes/api/goal.js
+++ b/routes/api/goal.js
@@ -93,9 +93,13 @@ router.get("/channel/:channel", (req, res) => {
 //@desc     Get the accessToken from the :token
 //@access   Public
 //TODO      Make this require authentication
-router.get("/accessToken/:token", (req, res) => {
+router.get("/channelInfo/:token", (req, res) => {
     Goal.findOne({ socketToken: req.params.token }).then((goal) =>
-        res.json({ accessToken: goal.accessToken })
+        res.json({
+            channel: goal.channel,
+            progress: goal.progress,
+            accessToken: goal.accessToken,
+        })
     );
 });
 


### PR DESCRIPTION
* Updated accessToken endpoint to channelInfo.
* channelInfo includes channel name, current progress, and the access token.
* Removed calls to updateProgress endpoint from the frontend. This prevents multiple calls from happening when there are multiple tabs/windows opened.